### PR TITLE
Add function for getting json-proof app name

### DIFF
--- a/src/main/resources/site/lib/enonic/util/app.js
+++ b/src/main/resources/site/lib/enonic/util/app.js
@@ -10,3 +10,12 @@ exports.getShortName = function () {
     var appName = app.name;
     return appName.split('.').pop();
 };
+
+/**
+ * Get app's name for use in JSON-nodes (com.enonic.app as com-enonic-app)
+ * @returns {String}
+ */
+exports.getJsonName = function () {
+    var appName = app.name;
+    return appName.replace(/\./g, '-');
+};


### PR DESCRIPTION
This is used in many other apps and done "manually" which is a bit easy to forget. Better to just add here in lib-util to make it even more useful.