### PR TITLE
Add content.getInOrder(contentIDs)

### DIFF
--- a/src/main/resources/site/lib/enonic/util/content.js
+++ b/src/main/resources/site/lib/enonic/util/content.js
@@ -81,3 +81,12 @@ exports.getInOrder = function(contentIDs) {
     });
     return contentArray;
 };
+
+/**
+ * Get the query for an array of content IDs or a single ID string. Useful for getting multiple content from ContentSelectors
+ * @param {array or string} contentIDs - Array of content IDs or a single ID as a string
+ * @returns {string} Query string for array of content IDs '_id IN ("c300beed-3777-4a5d-87a7-4a8ee743ea76", "d04c31e5-eb63-4921-bec5-1672b4a80bd5")'
+ */
+exports.getQueryFromIDs = function(contentIDs) {
+    return '_id IN (' + JSON.stringify(contentIDs).replace('[','').replace(']','') + ')';
+};

--- a/src/main/resources/site/lib/enonic/util/content.js
+++ b/src/main/resources/site/lib/enonic/util/content.js
@@ -62,3 +62,22 @@ exports.getPath = function (contentKey) {
     }
     return contentPath ? contentPath : defaultContent._path;
 };
+
+/**
+ * Gets content from a content ID (string) or an array of content IDs. Very useful for ContentSelectors.
+ * @param {array or string} contentIDs - Array of content IDs or a single content ID as a string.
+ * @returns {array} Array of content items
+ */
+exports.getInOrder = function(contentIDs) {
+    if (!Array.isArray(contentIDs)) {
+        contentIDs = [contentIDs];
+    }
+    var contentArray = [];
+    contentIDs.map(function(id) {
+        var content = libs.content.get({key: id});
+        if(content) {
+            contentArray.push(content);
+        }
+    });
+    return contentArray;
+};


### PR DESCRIPTION
Many times I find myself getting content from a ContentSelector or ImageSelector in a part config with multiple contents. The config drag and drop order does not work unless you get each content in order. So I keep using this same bit of code all over the place. It would only take one line with this util function. 
With this function you can do this:
var images = libs.util.content.getInOrder(config.images);
And now you have an array of the config content in the same order that exists in the part config.