### PR TITLE
toStr - Syntactic sugar for JSON.stringify

### DIFF
--- a/src/main/resources/site/lib/enonic/util/index.js
+++ b/src/main/resources/site/lib/enonic/util/index.js
@@ -10,3 +10,16 @@ exports.region = require('region');
 exports.log = function (data) {
     log.info('UTIL log %s', JSON.stringify(data, null, 4));
 };
+
+/**
+ * Syntactic sugar for JSON.stringify
+ * @param {*} value
+ * @param {Function} replacer - default: null
+ * @param {String|Number} space - default: 4
+ * @returns {String} A JSON string representing the given value.
+ */
+exports.toStr = function(value) {
+    var replacer = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
+    var space = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 4;
+    return JSON.stringify(value, replacer, space);
+};


### PR DESCRIPTION
Getting tired of writing

```
log.info('value:%s other:%s', JSON.stringify(value, null, 4), JSON.stringify(other, null, 4));
```

A bit shorter, yes?

```
log.info('value:%s other:%s', toStr(value), toStr(other));
```

Ecmascript 2015

```
log.info(`value:${toStr(value)} other:${toStr(other)}`);
```