### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,10 @@ plugins {
 }
 
 dependencies {
-	compileOnly "com.enonic.xp:lib-admin:${xpVersion}" // /lib/util/portal/getLocale.es
-	compileOnly "com.enonic.xp:lib-content:${xpVersion}" // /lib/util/portal/getLocale.es
-	compileOnly "com.enonic.xp:lib-context:${xpVersion}" // /lib/util/content/getSites.es
-	compileOnly "com.enonic.xp:lib-portal:${xpVersion}" // /lib/util/portal/getLocale.es
+	compileOnly xplibs.admin   // /lib/util/portal/getLocale.es
+	compileOnly xplibs.content // /lib/util/portal/getLocale.es
+	compileOnly xplibs.context // /lib/util/content/getSites.es
+	compileOnly xplibs.portal  // /lib/util/portal/getLocale.es
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-util
-xpVersion = 7.1.0
+xpVersion = 8.0.0-B4
 version=3.1.2-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+	id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
## Summary

Migrates `enonic/lib-util` from XP 7 to XP 8 per the [`xp-app-upgrader`](https://raw.githubusercontent.com/enonic/ai-agents-skills/master/skills/xp-app-upgrader/SKILL.md) workflow.

This is a JavaScript-only library (no `application.xml`, no `site/`, no `admin/`, no Java sources, no JUnit), so the upgrade is build-system only — no `xp8migrator` run needed.

## What changed

| Area | Before | After |
| --- | --- | --- |
| `xpVersion` | `7.1.0` | `8.0.0-B4` |
| `settings.gradle` | (none) | `com.enonic.xp.settings` plugin `4.0.0-B1` (verified live on plugins.gradle.org) |
| `build.gradle` deps | `compileOnly "com.enonic.xp:lib-{admin,content,context,portal}:${xpVersion}"` | `compileOnly xplibs.{admin,content,context,portal}` |
| Gradle wrapper | `8.0.2` | `9.4.1` (required by settings plugin 4.x) |

## Notes

- `com.enonic.defaults 2.1.6` retained — the existing `LICENSE.txt` satisfies its Gradle 9 license-presence check.
- No app-only artifacts present (`application.xml`, `site/`, `admin/`, `services/`, `migrator`), so the cleanup phase from the skill was a no-op.
- No JUnit tests, so the `org.junit.platform:junit-platform-launcher` Gradle 9 fixup was not needed.
- Wrapper bump required temporarily moving `settings.gradle` / `build.gradle` aside (settings plugin 4.0.0-B1 needs Java 21+ but Gradle 8.0.2 capped at Java 17), then restoring them after the wrapper task.

## Validation

`./gradlew clean build` is green locally on Java 21. **Runtime verification was not performed** — the runner's sandbox is ephemeral and out of scope per the upgrade brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)