### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Maintenance branch `3.x` created at SHA `059ce03` (the post-`v3.1.1` SNAPSHOT commit, `version=3.1.2-SNAPSHOT`).
- `gradle.properties` already declares `version=4.0.0-SNAPSHOT` on master, so no version edit needed here.
- Adds `releaseBranch: master\n3.x` to the build-and-publish action so both lines are recognized as release branches.

A companion PR against `3.x` (`chore/3.x-add-release-branch`) makes the same workflow edit on the maintenance branch — required so pushes to `3.x` are classified as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)