### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `releaseBranch: master\n3.x` to the `enonic/release-tools/build-and-publish` action on the `3.x` maintenance branch.
- Required so pushes to `3.x` are classified as release-branch builds — the action reads `releaseBranch:` from the branch's own workflow file.
- No version bump, no other changes — those belong on master only (companion PR #193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)